### PR TITLE
Add Journald 'forward to kernel log buffer' option

### DIFF
--- a/dracut/99journald-conf/00-journal-log-forwarding.conf
+++ b/dracut/99journald-conf/00-journal-log-forwarding.conf
@@ -1,2 +1,3 @@
 [Journal]
 ForwardToConsole=yes
+ForwardToKMsg=yes

--- a/dracut/99journald-conf/module-setup.sh
+++ b/dracut/99journald-conf/module-setup.sh
@@ -7,6 +7,6 @@ depends() {
 }
 
 install() {
-    inst_simple "$moddir/00-forward-to-console.conf" \
-        "/etc/systemd/journald.conf.d/00-forward-to-console.conf"
+    inst_simple "$moddir/00-journal-log-forwarding.conf" \
+        "/etc/systemd/journald.conf.d/00-journal-log-forwarding.conf"
 }


### PR DESCRIPTION
This makes ignition logs show up on ttyS0. Without this option, ignition logs only shows up on tty0.

Related to https://github.com/openshift/os/pull/158