### PR TITLE
change the default level of messages send to kmsg

### DIFF
--- a/dracut/99journald-conf/00-journal-log-forwarding.conf
+++ b/dracut/99journald-conf/00-journal-log-forwarding.conf
@@ -1,3 +1,4 @@
 [Journal]
 ForwardToConsole=yes
 ForwardToKMsg=yes
+MaxLevelKMsg=info


### PR DESCRIPTION
It defaults to notice, which doesn't print out the "info"
level information we want to get from ignition.