### PR TITLE
dracut/ignition: remove CL-legacy udev references

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -56,7 +56,4 @@ install() {
 
 #   inst_simple "$moddir/coreos-static-network.service" \
 #       "$systemdsystemunitdir/coreos-static-network.service"
-
-#   inst_rules \
-#       60-cdrom_id.rules
 }


### PR DESCRIPTION
This drop some legacy/commented line for installing CL-specific udev
rules. We'll likely grow some more bits to install into initramfs in
the future, which should not be part of this ignition module.