### PR TITLE
journal: don't log to console AND kmsg

### DIFF
--- a/dracut/99journald-conf/00-journal-log-forwarding.conf
+++ b/dracut/99journald-conf/00-journal-log-forwarding.conf
@@ -1,4 +1,3 @@
 [Journal]
-ForwardToConsole=yes
 ForwardToKMsg=yes
 MaxLevelKMsg=info


### PR DESCRIPTION
if we do that then we get "double logs" on the console device
because both kmsg and console output is getting dumped there.