### PR TITLE
module-setup.sh: explicitly install qemu_fw_cfg

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -59,3 +59,8 @@ install() {
 #   inst_simple "$moddir/coreos-static-network.service" \
 #       "$systemdsystemunitdir/coreos-static-network.service"
 }
+
+installkernel() {
+    # We definitely need this one in the initrd to support Ignition cfgs on qemu
+    instmods -c qemu_fw_cfg
+}


### PR DESCRIPTION
Make it explicit that we need the `qemu_fw_cfg` kernel module in the
initramfs. This works for Fedora right now before I think because we run
dracut with `--no-host-only` at compose time. (It's the default if
`initramfs-args` isn't in the manifest, as in FCOS, and in FAH we
explicitly have it in the manifest).

Closes: #22